### PR TITLE
Improved config file loading

### DIFF
--- a/src/pymmcore_plus_sandbox/_utils.py
+++ b/src/pymmcore_plus_sandbox/_utils.py
@@ -1,0 +1,38 @@
+from qtpy.QtGui import QFontMetrics, QGuiApplication
+from qtpy.QtWidgets import QDialog, QDialogButtonBox, QGridLayout, QLabel, QTextEdit
+
+
+class ErrorMessageBox(QDialog):
+    """A helper widget for creating (and immediately displaying) popups"""
+
+    def __init__(self, title: str, error_message: str, *args, **kwargs) -> None:
+        QDialog.__init__(self, *args, **kwargs)
+        self.setWindowTitle("Error")
+        self._layout = QGridLayout()
+        # Write the title to a Label
+        self._layout.addWidget(QLabel(title, self), 0, 0, 1, self._layout.columnCount())
+
+        # Write the error message to a TextEdit
+        msg_edit = QTextEdit(self)
+        msg_edit.setReadOnly(True)
+        msg_edit.setText(error_message)
+        self._layout.addWidget(msg_edit, 1, 0, 1, self._layout.columnCount())
+        msg_edit.setLineWrapMode(QTextEdit.NoWrap)
+
+        # Default size - size of the error message
+        font = msg_edit.document().defaultFont()
+        fontMetrics = QFontMetrics(font)
+        textSize = fontMetrics.size(0, error_message)
+        textWidth = textSize.width() + 100
+        textHeight = textSize.height() + 100
+        self.resize(textWidth, textHeight)
+        # Maximum size - ~80% of the user's screen
+        screen_size = QGuiApplication.primaryScreen().size()
+        self.setMaximumSize(
+            int(screen_size.width() * 0.8), int(screen_size.height() * 0.8)
+        )
+
+        btn_box = QDialogButtonBox(QDialogButtonBox.Ok)
+        btn_box.accepted.connect(self.accept)
+        self._layout.addWidget(btn_box, 2, 0, 1, self._layout.columnCount())
+        self.setLayout(self._layout)


### PR DESCRIPTION
Originally designed to solve the remaining issues described in #2, this PR makes the following changes:
* Added a new error message dialog box, heavily inspired by [this widget](https://github.com/imagej/napari-imagej/blob/e2bfdebff719e0192fb446cb3c8d844a78a98a70/src/napari_imagej/widgets/widget_utils.py#L107) I wrote for napari-imagej. The idea is to capture any exceptions within the text box inside the dialog, such that users can easily paste it into an issue on this repository.
* Improvements to the `ShuttersToolbar` widget to discard old shutters when loading a new configuration. These changes were made when trying to load `SequenceTester` (at @marktsuchida's suggestion) - loading that configuration works without issues now.

Closes #2