### PR TITLE
Qt Console Tool: First cut

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,14 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "cmap",
+    "IPython",
+    "ipykernel",
     "ndv@git+https://github.com/pyapp-kit/ndv.git@b79241c146bcbbb8160925f8cafbe8734ff75cef",
     "numpy<2",
     "PyQt6",
     "pymmcore-plus",
     "pymmcore-widgets",
+    "qtconsole",
     "vispy",
     "useq-schema",
     "zarr",

--- a/src/pymmcore_plus_sandbox/_console_widget.py
+++ b/src/pymmcore_plus_sandbox/_console_widget.py
@@ -1,0 +1,46 @@
+from qtconsole.inprocess import QtInProcessKernelManager
+from qtconsole.rich_jupyter_widget import RichJupyterWidget
+
+
+class QtConsole(RichJupyterWidget):
+    """A Qt widget for an IPython console, providing access to UI components.
+
+    Heavily borrowed from napari's Qt console:
+    https://github.com/napari/napari-console/blob/e2a8d7120a179c26295431a5c40820dcda6bb8f0/napari_console/qt_console.py#L1
+    """
+
+    def __init__(self, user_variables: dict | None = None):
+        if user_variables is None:
+            user_variables = {}
+        super().__init__()
+        self.setWindowTitle("PyMMCore Plus Sandbox Console")
+
+        # this makes calling `setFocus()` on a QtConsole give keyboard focus to
+        # the underlying `QTextEdit` widget
+        self.setFocusProxy(self._control)
+
+        # Create an in-process kernel
+        self.kernel_manager = QtInProcessKernelManager()
+        self.kernel_manager.start_kernel(show_banner=False)
+        self.kernel_manager.kernel.gui = "qt"
+        self.kernel_client = self.kernel_manager.client()
+        self.kernel_client.start_channels()
+        self.shell = self.kernel_manager.kernel.shell
+        self.push = self.shell.push
+
+        # Add any user variables
+        self.push(user_variables)
+
+    def closeEvent(self, event):
+        """Clean up the integrated console in napari."""
+
+        if self.kernel_client is not None:
+            self.kernel_client.stop_channels()
+        if self.kernel_manager is not None and self.kernel_manager.has_kernel:
+            self.kernel_manager.shutdown_kernel()
+
+        # RichJupyterWidget doesn't clean these up
+        self._completion_widget.deleteLater()
+        self._call_tip_widget.deleteLater()
+        self.deleteLater()
+        event.accept()


### PR DESCRIPTION
This PR adds a console tool, from which users can interrogate:
* The `CMMCorePlus` instance, using the `mmc` variable
* The `Viewfinder` instance, using the `viewfinder` variable
* Any existing `MDASequence` window, using the `mdas` variable

The widget itself was heavily inspired/borrowed from [napari-console](https://github.com/napari/napari-console) (see the [widget](https://github.com/napari/napari-console/blob/main/napari_console/qt_console.py#L1))

@marktsuchida can you think of any other objects with current value?