### PR TITLE
Enable RGB outputs

### DIFF
--- a/src/pymmcore_plus_sandbox/__init__.py
+++ b/src/pymmcore_plus_sandbox/__init__.py
@@ -390,7 +390,8 @@ class APP(QMainWindow):
                 return
             try:
                 if self.viewfinder:
-                    self.viewfinder.set_data(self._mmc.getLastImage())
+                    img = self._mmc.getLastImage()
+                    self.viewfinder.set_data(self._mmc.fixImage(img))
             except (RuntimeError, IndexError):
                 # circular buffer empty
                 return


### PR DESCRIPTION
This PR enables smooth RGB image viewing. It is a draft PR because it requires pyapp-kit/ndv#41 to work. Once that is merged, we need to bump the version (i.e. Git commit) of that repository here.